### PR TITLE
 Add notationPatterns to kos.yaml 

### DIFF
--- a/kos.yaml
+++ b/kos.yaml
@@ -424,3 +424,15 @@ wd:
   - en
   license:
   - uri: http://creativecommons.org/publicdomain/zero/1.0/
+  
+zdb-fgs:
+  prefLabel:
+    de: ZDB-Fachgruppensystematik
+    en: ZDB-Classification
+  uri: https://bartoc.org/de/node/18915
+  notation:
+    - ZDB-FGS
+  type:
+  - http://w3id.org/nkos/nkostype#classification_schema
+  notationPattern: '[0-9]{3}'
+  namespace: http://uri.gbv.de/terminology/zdb-fgs/

--- a/kos.yaml
+++ b/kos.yaml
@@ -136,7 +136,7 @@ asb:
   - H
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
-  - notationPattern: '[A-Z]+( [0-9]+)?'
+  notationPattern: '[A-Z]+( [0-9]+)?'
   
 
 ssd:
@@ -151,7 +151,7 @@ ssd:
   PICAPATH: 045B[01]$a
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
-  - notationPattern: '[A-Z]+( [0-9]+)?'
+  notationPattern: '[A-Z]+( [0-9]+)?'
   
 
 sfb:
@@ -181,7 +181,7 @@ kab:
   PICAPATH: 045B[03]$a
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
-  - notationPattern: '[A-Z]( [0-9]+(.?[0-9])?)?'
+  notationPattern: '[A-Z]( [0-9]+(.?[0-9])?)?'
 
 aadgenres:
   uri: https://bartoc.org/en/node/18627
@@ -222,7 +222,7 @@ nlm:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - ÖSÖB
-  - notationPattern: '[A-Z]+(.[A-Z]+)?'
+  notationPattern: '[A-Z]+(.[A-Z]+)?'
 
 bos:
   prefLabel:
@@ -298,6 +298,7 @@ fbup:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - FBUP
+  notationPattern: '[A-Z]+(-[A-Z]+)?'
 
 fud:
   prefLabel:
@@ -474,7 +475,8 @@ cerl:
     de: CERL Thesaurus
     en: CERL Thesaurus
   uri: https://bartoc.org/de/node/1413
-  notation: CERL
+  notation: 
+  - CERL
   type: 
   - http://w3id.org/nkos/nkostype#thesaurus
   notationPattern: '[a-z]{3}[0-9]{8}'

--- a/kos.yaml
+++ b/kos.yaml
@@ -6,7 +6,7 @@ ddc:
   prefLabel:
     de: Dewey-Dezimalklassifikation
   uriPattern: 'http://dewey.info/class/(.+)/e23/'
-  notationPattern: '[0-9][0-9]?|[0-9]{3}(-[0-9]{3})?|[0-9]{3}\.[0-9]+(-[0-9]{3}\.[0-9]+)?|[1-9][A-Z]?--[0-9]+|[1-9][A-Z]?--[0-9]+(-[1-9][A-Z]?--[0-9]+)?'
+  notationPattern: '[A-Z0-9]+(.[0-9]+|--[0-9]*(-[0-9]*)?)?'
   CQLKEY: ddc
   EXAMPLES:
   - '612.112'
@@ -32,7 +32,7 @@ bk:
   uri: http://bartoc.org/en/node/18785
   notation: ['BK']
   namespace: 'http://uri.gbv.de/terminology/bk/'
-  notationPattern: '(0|1-2|3-4|5|7-8|[0-9]{2}(\.[0-9]{2})?)'
+  notationPattern: '[0-9]+(.[0-9]*)?'
   prefLabel:
     de: Basisklassifikation
   CQLKEY: BKL
@@ -60,7 +60,7 @@ stw:
   uri: http://bartoc.org/en/node/313
   notation: ['STW']
   namespace: http://zbw.eu/stw/descriptor/
-  notationPattern: '[0-9]+-[0-9]'
+  notationPattern: '[A-Z]+(.[0-9]+)?(.[0-9]+)?(.[0-9]+)?'
   CQLKEY: STT
   EXAMPLES:
   - 13492-2
@@ -120,6 +120,7 @@ lcc:
   - B1-B5802
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
+  notationPattern: '[A-Z]+[0-9]+(.[0-9]+)?(.[A-Z0-9]+(.[0-9]+))?'
 
 #not fully supported yet
 asb:
@@ -135,6 +136,8 @@ asb:
   - H
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
+  - notationPattern: '[A-Z]+( [0-9]+)?'
+  
 
 ssd:
   notation:
@@ -148,6 +151,8 @@ ssd:
   PICAPATH: 045B[01]$a
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
+  - notationPattern: '[A-Z]+( [0-9]+)?'
+  
 
 sfb:
   CQLKEY: SFB
@@ -161,6 +166,8 @@ sfb:
   - EDV 5
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
+  notationPattern: '[A-Z]+ [0-9]+(.[0-9]| [A-Z] - [A-Z])?'
+  
 
 kab:
   uri: http://bartoc.org/en/node/1031
@@ -174,6 +181,7 @@ kab:
   PICAPATH: 045B[03]$a
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
+  - notationPattern: '[A-Z]( [0-9]+(.?[0-9])?)?'
 
 aadgenres:
   uri: https://bartoc.org/en/node/18627
@@ -203,6 +211,8 @@ nlm:
   - QU 21
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
+  notationPattern: '[A-Z]+ [0-9]+(.[0-9](.[A-Z0-9]+)?)?'
+  
 
 ösöb:
   prefLabel:
@@ -212,6 +222,7 @@ nlm:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - ÖSÖB
+  - notationPattern: '[A-Z]+(.[A-Z]+)?'
 
 bos:
   prefLabel:
@@ -238,6 +249,7 @@ fkdigbib:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - FKDigBib
+  notationPattern: '[0-9]+'
 
 kfm:
   prefLabel:
@@ -265,6 +277,8 @@ ghb:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - GHB
+  notationPattern: '[A-Z]+(-[A-Z]+)?'
+  
 
 essb:
   prefLabel:
@@ -274,6 +288,7 @@ essb:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - ESSB
+  notationPattern: '[A-Z]+ [0-9]?.?[0-9]?.?[0-9]?'
 
 fbup:
   prefLabel:
@@ -292,6 +307,7 @@ fud:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - FUD
+  notationPattern: '[A-Z]+([0-9]+)?'
 
 fum:
   prefLabel:
@@ -301,6 +317,8 @@ fum:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - FUM
+  notationPattern: '([A-Z]+ )?[0-9]+ - ([A-Z]+ )?[0-9]+'
+  
 
 gok:
   prefLabel:
@@ -310,6 +328,8 @@ gok:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - GOK
+  notationPattern: '[A-Z]+ ([0-9]{3}|XXX)'
+  
 
 dekla:
   prefLabel:
@@ -319,6 +339,7 @@ dekla:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - DEKLA
+  notationPattern: '[A-H] [0-9]+ [A-Z]*( [0-9]*\/[0-9]*)?'
 
 konsys:
   prefLabel:
@@ -328,6 +349,7 @@ konsys:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - KonSys
+  notationPattern: '[a-z]+ [0-9]+( - )?(:[a-z0-9]+)?( [-] )?|.[0-9]+(:[a-z]+)?( [-] )?'
 
 fuld:
   prefLabel:
@@ -337,6 +359,7 @@ fuld:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - FULD
+  notationPattern: '[a-z]{4}[0-9]+([+]| ff)?'
 
 msc:
   prefLabel:
@@ -347,6 +370,7 @@ msc:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - MSC
+  notationPattern: '[0-9]{2}(-?[A-Z]*[0-9]*)?'
 
 skb:
   prefLabel:
@@ -356,6 +380,7 @@ skb:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - SKB
+  notationPattern: '[A-Z]+( [0-9]+(.[0-9]+)?)?'
 
 pacs:
   prefLabel:
@@ -374,6 +399,7 @@ sulb:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - SULB
+  
 
 seb:
   prefLabel:
@@ -383,6 +409,7 @@ seb:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - SEB
+  notationPattern: '[A-Z]+([a-z] [0-9])?'
 
 skj:
   prefLabel:
@@ -392,6 +419,8 @@ skj:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - SKJ
+  notationPattern: '[1-7]+(.[1-3])?'
+  
 
 tum:
   prefLabel:
@@ -401,6 +430,7 @@ tum:
   - http://w3id.org/nkos/nkostype#classification_schema
   notation:
   - TUM
+  notationPattern: '[A-Z]{3} [0-9]{3}'
 
 udc:
   prefLabel:
@@ -408,6 +438,7 @@ udc:
   uri: http://bartoc.org/en/node/496
   type:
   - http://w3id.org/nkos/nkostype#classification_schema
+  notationPattern: '[0-9]+.[0-9]*.[0-9]*'
   notation:
   - UDC
 
@@ -419,6 +450,7 @@ wd:
   - WD
   identifier:
   - http://www.wikidata.org/entity/2013
+  notationPattern: 'Q[0-9]+'
   languages:
   - de
   - en
@@ -436,3 +468,14 @@ zdb-fgs:
   - http://w3id.org/nkos/nkostype#classification_schema
   notationPattern: '[0-9]{3}'
   namespace: http://uri.gbv.de/terminology/zdb-fgs/
+  
+cerl:
+  prefLabel:
+    de: CERL Thesaurus
+    en: CERL Thesaurus
+  uri: https://bartoc.org/de/node/1413
+  notation: CERL
+  type: 
+  - http://w3id.org/nkos/nkostype#thesaurus
+  notationPattern: '[a-z]{3}[0-9]{8}'
+  namespace: http://uri.gbv.de/terminology/cerl/


### PR DESCRIPTION
I deleted some notationPatterns from before, because they didn't work right. Still, someone should better check again.
